### PR TITLE
ci: create draft releases for tag deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,3 +82,27 @@ jobs:
 
           echo "Приложение или его ресурсы недоступны после деплоя"
           exit 1
+
+  release:
+    name: Create Draft Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Создать draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME уже существует"
+            exit 0
+          fi
+
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --draft \
+            --generate-notes


### PR DESCRIPTION
## Summary

- create a draft GitHub Release after a successful tag deployment
- generate release notes from repository history
- skip release creation for manual deployments
- avoid duplicate releases on workflow reruns

## Verification

- workflow YAML syntax validation
- workflow shell syntax validation
- security review of job permissions and tag conditions