### PR TITLE
docs(readme): use relative license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ If you want to use this editor in a proprietary application without open-sourcin
 
 ## License
 
-[AGPL-3.0](https://github.com/mysigmail/card/blob/master/LICENSE)
+[AGPL-3.0](LICENSE)
 
 Copyright (c) 2022-present, Anton Reshetov.


### PR DESCRIPTION
## Summary

- replace the branch-specific license URL with a relative repository link
- keep README valid after renaming the default branch from `master` to `main`

## Verification

- GitHub default branch is `main`
- workflows contain no `master` branch filters
- repository diff contains only the README link update