### PR TITLE
refactor(text): remove legacy atom color

### DIFF
--- a/src/entities/block/block-factory.ts
+++ b/src/entities/block/block-factory.ts
@@ -55,8 +55,7 @@ export function createTextAtom(value = '<p>Text</p>'): TextAtom {
   return {
     id: nanoid(8),
     type: 'text',
-    value,
-    color: '#111827',
+    value: `<div style="color:#111827">${value}</div>`,
     spacing: createAtomSpacing(),
   }
 }

--- a/src/entities/block/types.ts
+++ b/src/entities/block/types.ts
@@ -10,7 +10,6 @@ export interface BaseAtom {
 export interface TextAtom extends BaseAtom {
   type: 'text'
   value: string
-  color: string
 }
 
 export interface ButtonAtom extends BaseAtom {

--- a/src/entities/template/template-io.ts
+++ b/src/entities/template/template-io.ts
@@ -529,10 +529,6 @@ function validateAtom(value: unknown, path: string, issues: TemplateValidationIs
     if (!isString(value.value))
       pushIssue(issues, `${path}.value`, 'text atom value must be a string')
 
-    if (value.color !== undefined && !isString(value.color)) {
-      pushIssue(issues, `${path}.color`, 'text atom color must be a string')
-    }
-
     if (value.spacing !== undefined)
       validateSpacingValue(value.spacing, `${path}.spacing`, issues)
 
@@ -1035,10 +1031,11 @@ function sanitizeAtoms(atoms: Atom[]): Atom[] {
   return atoms.map((atom) => {
     if (atom.type === 'text') {
       return {
-        ...atom,
-        hiddenOnMobile: toOptionalBoolean(atom.hiddenOnMobile),
-        color: atom.color || '#111827',
+        id: atom.id,
+        type: atom.type,
         value: sanitizeTextEditorHtml(atom.value),
+        spacing: atom.spacing,
+        hiddenOnMobile: toOptionalBoolean(atom.hiddenOnMobile),
       }
     }
 

--- a/src/features/editor/model/use-canvas-tools.ts
+++ b/src/features/editor/model/use-canvas-tools.ts
@@ -192,11 +192,6 @@ function _createCanvasTools() {
       if (field === 'content')
         return updateTextAtomValue(atom.id, String(value ?? ''))
 
-      if (field === 'color') {
-        atom.color = String(value ?? '')
-        return true
-      }
-
       if (field === 'spacing') {
         atom.spacing = toSpacingValue(value)
         return true

--- a/src/features/email-preview/catalog/blocks/content1.json
+++ b/src/features/email-preview/catalog/blocks/content1.json
@@ -41,8 +41,7 @@
               {
                 "id": "h7acjiWh",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">EDITOR'S NOTE / 01</span></strong></p><p><strong><span style=\"font-size:38px\">The useful part starts before the big idea.</span></strong></p><p><span style=\"color:#7A6558;font-size:17px\">A text-first opening for a point of view, announcement or thoughtful introduction.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">EDITOR'S NOTE / 01</span></strong></p><p><strong><span style=\"font-size:38px\">The useful part starts before the big idea.</span></strong></p><p><span style=\"color:#7A6558;font-size:17px\">A text-first opening for a point of view, announcement or thoughtful introduction.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -106,8 +105,7 @@
               {
                 "id": "F__w2E_S",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:16px\">Start with context</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Explain what changed and why the reader should care now.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:16px\">Start with context</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Explain what changed and why the reader should care now.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -139,8 +137,7 @@
               {
                 "id": "9QyWJNb_",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:16px\">End with direction</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Give the next section a clear promise instead of another headline.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:16px\">End with direction</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Give the next section a clear promise instead of another headline.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content10.json
+++ b/src/features/email-preview/catalog/blocks/content10.json
@@ -41,8 +41,7 @@
               {
                 "id": "QRJHnOME",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">TWO PERSPECTIVES</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:30px\">What changed after the first week.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">TWO PERSPECTIVES</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:30px\">What changed after the first week.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "TMYC-8cT",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:30px\">“</span></strong></p><p><strong><span style=\"font-size:19px\">We stopped explaining the interface and started discussing the work.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Maya Chen · Product lead</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:30px\">“</span></strong></p><p><strong><span style=\"font-size:19px\">We stopped explaining the interface and started discussing the work.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Maya Chen · Product lead</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +140,7 @@
               {
                 "id": "5I6UAJuf",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:30px\">“</span></strong></p><p><strong><span style=\"font-size:19px\">The handoff became shorter because the structure already carried intent.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Noah Ellis · Design director</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:30px\">“</span></strong></p><p><strong><span style=\"font-size:19px\">The handoff became shorter because the structure already carried intent.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Noah Ellis · Design director</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content11.json
+++ b/src/features/email-preview/catalog/blocks/content11.json
@@ -41,8 +41,7 @@
               {
                 "id": "ETpBmbTv",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:rgb(255, 107, 0);font-size:31px\"><strong>Our Clients</strong></span></p><p style=\"text-align:center\"><span style=\"font-size:16px\">We’re trusted by well-known companies,<br />and here are some of them.</span></p>",
-                "color": "#ffffff",
+                "value": "<div style=\"color:#ffffff\"><p style=\"text-align:center\"><span style=\"color:rgb(255, 107, 0);font-size:31px\"><strong>Our Clients</strong></span></p><p style=\"text-align:center\"><span style=\"font-size:16px\">We’re trusted by well-known companies,<br />and here are some of them.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content12.json
+++ b/src/features/email-preview/catalog/blocks/content12.json
@@ -41,8 +41,7 @@
               {
                 "id": "bjUKZoxb",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD INTERVIEW / 04</span></strong></p><p><strong><span style=\"font-size:32px\">The demonstration that changed the conversation.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD INTERVIEW / 04</span></strong></p><p><strong><span style=\"font-size:32px\">The demonstration that changed the conversation.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -162,8 +161,7 @@
               {
                 "id": "sLzuaCZI",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:19px\">Start with the object, then explain the choice.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Maya placed the can in view before describing the redesign. That small sequence gave the audience something concrete to inspect while the reasoning unfolded.</span></p><p><span style=\"color:#7A6558;font-size:14px\">The result felt less like a pitch and more like a useful working note.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:19px\">Start with the object, then explain the choice.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Maya placed the can in view before describing the redesign. That small sequence gave the audience something concrete to inspect while the reasoning unfolded.</span></p><p><span style=\"color:#7A6558;font-size:14px\">The result felt less like a pitch and more like a useful working note.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -233,8 +231,7 @@
               {
                 "id": "e6MnQrQX",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:12px\">KEY DETAIL</span></strong></p><p><strong><span style=\"font-size:21px\">Show first.<br />Explain second.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">A compact takeaway separated from the main narrative.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:12px\">KEY DETAIL</span></strong></p><p><strong><span style=\"font-size:21px\">Show first.<br />Explain second.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">A compact takeaway separated from the main narrative.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content13.json
+++ b/src/features/email-preview/catalog/blocks/content13.json
@@ -41,8 +41,7 @@
               {
                 "id": "OM92n8zu",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">THE QUARTER IN THREE NUMBERS</span></strong></p><p><strong><span style=\"font-size:30px\">A compact data story, not a dashboard.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">THE QUARTER IN THREE NUMBERS</span></strong></p><p><strong><span style=\"font-size:30px\">A compact data story, not a dashboard.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -93,8 +92,7 @@
               {
                 "id": "XzLaYl1L",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:36px\">42%</span></strong></p><p><strong>Faster first draft</strong></p><p><span style=\"color:#7A6558;font-size:13px\">Measured from brief to review-ready structure.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:36px\">42%</span></strong></p><p><strong>Faster first draft</strong></p><p><span style=\"color:#7A6558;font-size:13px\">Measured from brief to review-ready structure.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -126,8 +124,7 @@
               {
                 "id": "xZVvqweg",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:36px\">3.1×</span></strong></p><p><strong>More reuse</strong></p><p><span style=\"color:#7A6558;font-size:13px\">Teams started from proven patterns instead of blank pages.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:36px\">3.1×</span></strong></p><p><strong>More reuse</strong></p><p><span style=\"color:#7A6558;font-size:13px\">Teams started from proven patterns instead of blank pages.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -159,8 +156,7 @@
               {
                 "id": "Ko73sYfm",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:36px\">18h</span></strong></p><p><strong>Saved weekly</strong></p><p><span style=\"color:#7A6558;font-size:13px\">A clear number with one sentence of useful context.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:36px\">18h</span></strong></p><p><strong>Saved weekly</strong></p><p><span style=\"color:#7A6558;font-size:13px\">A clear number with one sentence of useful context.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content14.json
+++ b/src/features/email-preview/catalog/blocks/content14.json
@@ -41,8 +41,7 @@
               {
                 "id": "bbg6_Yki",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:34px\">“</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:21px\">The strongest improvement was not a new feature. It was finally having a starting point the whole team understood.</span></p>",
-                "color": "#7A6558",
+                "value": "<div style=\"color:#7A6558\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:34px\">“</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:21px\">The strongest improvement was not a new feature. It was finally having a starting point the whole team understood.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -84,8 +83,7 @@
               {
                 "id": "kRYtW9Ix",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:23px\">Alex Morgan</span></strong><br /><span style=\"color:#FF6B00;font-size:15px\">Customer experience lead</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:23px\">Alex Morgan</span></strong><br /><span style=\"color:#FF6B00;font-size:15px\">Customer experience lead</span></p></div>",
                 "spacing": {
                   "padding": [
                     18,

--- a/src/features/email-preview/catalog/blocks/content15.json
+++ b/src/features/email-preview/catalog/blocks/content15.json
@@ -41,8 +41,7 @@
               {
                 "id": "WdjplyFy",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">FROM THE EDITOR</span></strong></p><p><strong><span style=\"font-size:32px\">The detail worth carrying into the next draft.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">An editorial opening with a visible author, useful for columns, newsletters and expert commentary.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">FROM THE EDITOR</span></strong></p><p><strong><span style=\"font-size:32px\">The detail worth carrying into the next draft.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">An editorial opening with a visible author, useful for columns, newsletters and expert commentary.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +141,7 @@
               {
                 "id": "AsVEse-7",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:18px\">Amir Cole</span></strong><br /><span style=\"color:#FF6B00;font-size:13px\">EDITOR · PRODUCT &amp; CULTURE</span></p><p><span style=\"color:#7A6558;font-size:14px\">Writes about the small choices that make products easier to understand and remember.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:18px\">Amir Cole</span></strong><br /><span style=\"color:#FF6B00;font-size:13px\">EDITOR · PRODUCT &amp; CULTURE</span></p><p><span style=\"color:#7A6558;font-size:14px\">Writes about the small choices that make products easier to understand and remember.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content16.json
+++ b/src/features/email-preview/catalog/blocks/content16.json
@@ -41,8 +41,7 @@
               {
                 "id": "q1xBYVqH",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THREE NOTES FROM THE FIELD</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:30px\">Different teams. One clear shift.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THREE NOTES FROM THE FIELD</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:30px\">Different teams. One clear shift.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -177,8 +176,7 @@
                       {
                         "id": "XjqKLJpg",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“We found the right starting point in minutes.”</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“We found the right starting point in minutes.”</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -229,8 +227,7 @@
                       {
                         "id": "epajs8JX",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Maya Chen<br />Product lead</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Maya Chen<br />Product lead</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -350,8 +347,7 @@
                       {
                         "id": "4fvjDeNC",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“The structure made the feedback much sharper.”</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“The structure made the feedback much sharper.”</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -402,8 +398,7 @@
                       {
                         "id": "umOzAdWE",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Sofia Reed<br />Brand director</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Sofia Reed<br />Brand director</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -523,8 +518,7 @@
                       {
                         "id": "5p0td6Xn",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“Our first review finally stayed on the message.”</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:17px\">“Our first review finally stayed on the message.”</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -575,8 +569,7 @@
                       {
                         "id": "Q3o6n-Xa",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Daniel Brooks<br />Creative lead</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Daniel Brooks<br />Creative lead</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/content2.json
+++ b/src/features/email-preview/catalog/blocks/content2.json
@@ -42,8 +42,7 @@
               {
                 "id": "hlfy2pKz",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD STORY</span></strong></p><p><strong><span style=\"font-size:32px\">Pack less. Notice more.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A wide editorial feature for product stories, travel notes and campaign narratives.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD STORY</span></strong></p><p><strong><span style=\"font-size:32px\">Pack less. Notice more.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A wide editorial feature for product stories, travel notes and campaign narratives.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content3.json
+++ b/src/features/email-preview/catalog/blocks/content3.json
@@ -92,8 +92,7 @@
               {
                 "id": "vfWePPfl",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">CITY NOTES</span></strong></p><p><strong><span style=\"font-size:30px\">The everyday carry became the everyday system.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">Use a media-left story when the object opens the narrative and the copy explains the meaning.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">CITY NOTES</span></strong></p><p><strong><span style=\"font-size:30px\">The everyday carry became the everyday system.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">Use a media-left story when the object opens the narrative and the copy explains the meaning.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content4.json
+++ b/src/features/email-preview/catalog/blocks/content4.json
@@ -49,8 +49,7 @@
               {
                 "id": "RHZkxc3v",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">BEHIND THE SETUP</span></strong></p><p><strong><span style=\"font-size:30px\">Small tools can change the rhythm of a room.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A mirrored article start for reviews, interviews and product-led editorial.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">BEHIND THE SETUP</span></strong></p><p><strong><span style=\"font-size:30px\">Small tools can change the rhythm of a room.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A mirrored article start for reviews, interviews and product-led editorial.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content5.json
+++ b/src/features/email-preview/catalog/blocks/content5.json
@@ -125,8 +125,7 @@
                       {
                         "id": "CDVXqxUj",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:18px\">A better daily<br />ritual</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Three minutes on the object that quietly improved the morning.</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:18px\">A better daily<br />ritual</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Three minutes on the object that quietly improved the morning.</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -245,8 +244,7 @@
                       {
                         "id": "4RoalX-C",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:18px\">Play without<br />friction</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">What good controls teach us about clear interaction.</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:18px\">Play without<br />friction</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">What good controls teach us about clear interaction.</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -365,8 +363,7 @@
                       {
                         "id": "-GOgtYo1",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:18px\">Carry only the<br />useful</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">A short guide to editing the everyday kit.</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:18px\">Carry only the<br />useful</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">A short guide to editing the everyday kit.</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/content6.json
+++ b/src/features/email-preview/catalog/blocks/content6.json
@@ -85,8 +85,7 @@
               {
                 "id": "dwPYQxnq",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">01 / INPUT</span></strong></p><p><strong><span style=\"font-size:19px\">Make the frequent action feel obvious.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">A compact lesson with one concrete example.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">01 / INPUT</span></strong></p><p><strong><span style=\"font-size:19px\">Make the frequent action feel obvious.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">A compact lesson with one concrete example.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -137,8 +136,7 @@
               {
                 "id": "JQRpFzd9",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">02 / FOCUS</span></strong></p><p><strong><span style=\"font-size:19px\">Remove one choice before adding another.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">A second card that changes rhythm, not just media.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">02 / FOCUS</span></strong></p><p><strong><span style=\"font-size:19px\">Remove one choice before adding another.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">A second card that changes rhythm, not just media.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content7.json
+++ b/src/features/email-preview/catalog/blocks/content7.json
@@ -41,8 +41,7 @@
               {
                 "id": "BiP9yJb7",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">A SIMPLE PROCESS</span></strong></p><p><strong><span style=\"font-size:31px\">From rough thought to useful draft.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">A SIMPLE PROCESS</span></strong></p><p><strong><span style=\"font-size:31px\">From rough thought to useful draft.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "trfDWQ5D",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:30px\">01</span></strong></p><p><strong><span style=\"font-size:18px\">Frame it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Write the real question before searching for the answer.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:30px\">01</span></strong></p><p><strong><span style=\"font-size:18px\">Frame it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Write the real question before searching for the answer.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +140,7 @@
               {
                 "id": "-WC2btDJ",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:30px\">02</span></strong></p><p><strong><span style=\"font-size:18px\">Shape it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Choose a clear order and remove the duplicate moves.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:30px\">02</span></strong></p><p><strong><span style=\"font-size:18px\">Shape it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Choose a clear order and remove the duplicate moves.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -183,8 +180,7 @@
               {
                 "id": "bRmm9rD8",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:30px\">03</span></strong></p><p><strong><span style=\"font-size:18px\">Share it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">End with a next step the reader can actually take.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:30px\">03</span></strong></p><p><strong><span style=\"font-size:18px\">Share it</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">End with a next step the reader can actually take.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content8.json
+++ b/src/features/email-preview/catalog/blocks/content8.json
@@ -42,8 +42,7 @@
               {
                 "id": "7v_ir1ty",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">PACKING CHECKLIST</span></strong></p><p><strong><span style=\"font-size:31px\">Five decisions before the door closes.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">PACKING CHECKLIST</span></strong></p><p><strong><span style=\"font-size:31px\">Five decisions before the door closes.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -82,8 +81,7 @@
               {
                 "id": "E-_oBgGj",
                 "type": "text",
-                "value": "<p><strong>✓ Keep one layer within reach</strong></p><p><strong>✓ Separate work from charging</strong></p><p><strong>✓ Leave room for the return trip</strong></p><p><strong>✓ Put the fragile piece in the center</strong></p><p><strong>✓ Photograph the final arrangement</strong></p>",
-                "color": "#5A2B0A",
+                "value": "<div style=\"color:#5A2B0A\"><p><strong>✓ Keep one layer within reach</strong></p><p><strong>✓ Separate work from charging</strong></p><p><strong>✓ Leave room for the return trip</strong></p><p><strong>✓ Put the fragile piece in the center</strong></p><p><strong>✓ Photograph the final arrangement</strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/content9.json
+++ b/src/features/email-preview/catalog/blocks/content9.json
@@ -92,8 +92,7 @@
               {
                 "id": "hahnW7Uy",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:38px\">“</span></strong></p><p><strong><span style=\"font-size:27px\">The message finally sounds like the people who made it.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">A single testimonial with enough space for a real point of view.</span></p><p><strong>Amelia Reed</strong><br /><span style=\"color:#7A6558;font-size:13px\">Brand director, North Studio</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:38px\">“</span></strong></p><p><strong><span style=\"font-size:27px\">The message finally sounds like the people who made it.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">A single testimonial with enough space for a real point of view.</span></p><p><strong>Amelia Reed</strong><br /><span style=\"color:#7A6558;font-size:13px\">Brand director, North Studio</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-1.json
+++ b/src/features/email-preview/catalog/blocks/cta-1.json
@@ -85,8 +85,7 @@
               {
                 "id": "pCyXMyDz",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">READY TO SHIP</span></strong></p><p><strong><span style=\"font-size:22px\">Travel mug · Sand</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keeps the next cup close.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">READY TO SHIP</span></strong></p><p><strong><span style=\"font-size:22px\">Travel mug · Sand</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keeps the next cup close.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -118,8 +117,7 @@
               {
                 "id": "6sHma63z",
                 "type": "text",
-                "value": "<p style=\"text-align:right\"><strong><span style=\"font-size:23px\">$28</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><strong><span style=\"font-size:23px\">$28</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-10.json
+++ b/src/features/email-preview/catalog/blocks/cta-10.json
@@ -42,8 +42,7 @@
               {
                 "id": "7jMLgLOa",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFB16F;font-size:12px\">SEP</span></strong><br /><strong><span style=\"color:#FFFFFF;font-size:26px\">24</span></strong></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p style=\"text-align:center\"><strong><span style=\"color:#FFB16F;font-size:12px\">SEP</span></strong><br /><strong><span style=\"color:#FFFFFF;font-size:26px\">24</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -75,8 +74,7 @@
               {
                 "id": "mjGqHLSN",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFFFFF;font-size:22px\">Workshop starts at 10:00.</span></strong><br /><span style=\"color:#FFD9B8;font-size:13px\">12 seats remain · calendar invite included</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFFFFF;font-size:22px\">Workshop starts at 10:00.</span></strong><br /><span style=\"color:#FFD9B8;font-size:13px\">12 seats remain · calendar invite included</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-11.json
+++ b/src/features/email-preview/catalog/blocks/cta-11.json
@@ -41,8 +41,7 @@
               {
                 "id": "6HbFijHe",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKLY CIRCLE</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Good ideas get better in company.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:15px\">Join makers sharing useful work, honest notes and fresh references.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKLY CIRCLE</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Good ideas get better in company.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:15px\">Join makers sharing useful work, honest notes and fresh references.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-12.json
+++ b/src/features/email-preview/catalog/blocks/cta-12.json
@@ -42,8 +42,7 @@
               {
                 "id": "XVSupRAC",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:13px\">FREE FIELD GUIDE / PDF</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:31px\">A practical checklist for the next campaign.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A resource-first block that works without decorative imagery.</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:13px\">FREE FIELD GUIDE / PDF</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:31px\">A practical checklist for the next campaign.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A resource-first block that works without decorative imagery.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -76,8 +75,7 @@
               {
                 "id": "L1-mShjH",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:30px\">18</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:12px\">ACTIONABLE PAGES</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:30px\">18</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:12px\">ACTIONABLE PAGES</span></p></div>",
                 "spacing": {
                   "padding": [
                     18,

--- a/src/features/email-preview/catalog/blocks/cta-2.json
+++ b/src/features/email-preview/catalog/blocks/cta-2.json
@@ -42,8 +42,7 @@
               {
                 "id": "sMKaQTzi",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:23px\">Ready to make the next send count?</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">A compact prompt for one high-priority action.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:23px\">Ready to make the next send count?</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">A compact prompt for one high-priority action.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-3.json
+++ b/src/features/email-preview/catalog/blocks/cta-3.json
@@ -43,8 +43,7 @@
               {
                 "id": "IYjxIqzS",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:12px\">07</span></strong><br /><span style=\"color:#FFD9B8;font-size:11px\">LEFT TODAY</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:12px\">07</span></strong><br /><span style=\"color:#FFD9B8;font-size:11px\">LEFT TODAY</span></p></div>",
                 "spacing": {
                   "padding": [
                     14,
@@ -76,8 +75,7 @@
               {
                 "id": "YC4Yo_-d",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:23px\">Almost gone, not forgotten.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Get one short availability reminder before the batch closes.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:23px\">Almost gone, not forgotten.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Get one short availability reminder before the batch closes.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-4.json
+++ b/src/features/email-preview/catalog/blocks/cta-4.json
@@ -135,8 +135,7 @@
               {
                 "id": "eh-2vEfK",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:12px\">THE EDIT</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Two useful things. One short list.</span></strong></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:12px\">THE EDIT</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Two useful things. One short list.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-5.json
+++ b/src/features/email-preview/catalog/blocks/cta-5.json
@@ -78,8 +78,7 @@
               {
                 "id": "BNwrrlq7",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">OFFICE HOURS · 20 MIN</span></strong></p><p><strong><span style=\"font-size:23px\">Bring one question. Leave with a next step.</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Hosted by Maya Chen · Thursday at 14:00</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">OFFICE HOURS · 20 MIN</span></strong></p><p><strong><span style=\"font-size:23px\">Bring one question. Leave with a next step.</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Hosted by Maya Chen · Thursday at 14:00</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-6.json
+++ b/src/features/email-preview/catalog/blocks/cta-6.json
@@ -85,8 +85,7 @@
               {
                 "id": "IZlpqRps",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">DESKTOP APP · 4.2</span></strong></p><p><strong><span style=\"font-size:23px\">Keep the workspace one click away.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">DESKTOP APP · 4.2</span></strong></p><p><strong><span style=\"font-size:23px\">Keep the workspace one click away.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-7.json
+++ b/src/features/email-preview/catalog/blocks/cta-7.json
@@ -114,8 +114,7 @@
               {
                 "id": "KmDA4bNP",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:13px\">2 MINUTE STORY</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:31px\">See how the pieces come together.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A media-led CTA for demos and customer stories.</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:13px\">2 MINUTE STORY</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:31px\">See how the pieces come together.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A media-led CTA for demos and customer stories.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-8.json
+++ b/src/features/email-preview/catalog/blocks/cta-8.json
@@ -42,8 +42,7 @@
               {
                 "id": "jwa-b8We",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:29px\">Choose how you want to begin.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">Two clear paths without turning the block into a full landing page.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:29px\">Choose how you want to begin.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">Two clear paths without turning the block into a full landing page.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/cta-9.json
+++ b/src/features/email-preview/catalog/blocks/cta-9.json
@@ -88,8 +88,7 @@
               {
                 "id": "tBb48pb4",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">48 HOURS ONLY</span></strong></p><p><strong><span style=\"font-size:30px\">Take 20% off the layer everyone wants.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Use code</span> <strong><span style=\"font-size:18px\">WARM20</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">48 HOURS ONLY</span></strong></p><p><strong><span style=\"font-size:30px\">Take 20% off the layer everyone wants.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Use code</span> <strong><span style=\"font-size:18px\">WARM20</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/ecommerce1.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce1.json
@@ -41,8 +41,7 @@
               {
                 "id": "QPcoKmxv",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">THE DESK EDIT</span></strong></p><p><strong><span style=\"font-size:31px\">One featured upgrade, three useful additions.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">THE DESK EDIT</span></strong></p><p><strong><span style=\"font-size:31px\">One featured upgrade, three useful additions.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -123,8 +122,7 @@
               {
                 "id": "dh9WWP4B",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:12px\">FEATURED</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Focus Headphones</span></strong></p><p><span style=\"color:#FFD9B8;font-size:13px\">Soft ear cups · wireless · 32h battery</span></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">$159</span></strong></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:12px\">FEATURED</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Focus Headphones</span></strong></p><p><span style=\"color:#FFD9B8;font-size:13px\">Soft ear cups · wireless · 32h battery</span></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">$159</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     14,
@@ -245,8 +243,7 @@
                       {
                         "id": "y8cp7u3B",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:17px\">Desk Camera</span></strong><br /><span style=\"color:#7A6558;font-size:12px\">4K · auto framing</span><br /><strong><span style=\"font-size:19px\">$89</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:17px\">Desk Camera</span></strong><br /><span style=\"color:#7A6558;font-size:12px\">4K · auto framing</span><br /><strong><span style=\"font-size:19px\">$89</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             10,
@@ -308,8 +305,7 @@
                       {
                         "id": "04Wq2EwR",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"font-size:17px\"><strong>City</strong></span><br /><span style=\"font-size:17px\"><strong>Pack</strong></span><br /><span style=\"color:rgb(90, 43, 10);font-size:12px\">16 L · laptop sleeve</span><br /><span style=\"font-size:19px\"><strong>$74</strong></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"font-size:17px\"><strong>City</strong></span><br /><span style=\"font-size:17px\"><strong>Pack</strong></span><br /><span style=\"color:rgb(90, 43, 10);font-size:12px\">16 L · laptop sleeve</span><br /><span style=\"font-size:19px\"><strong>$74</strong></span></p></div>",
                         "spacing": {
                           "padding": [
                             10,
@@ -368,8 +364,7 @@
                       {
                         "id": "FrdZJNZt",
                         "type": "text",
-                        "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">COMPLETE THE DESK</span></strong></p><p><strong><span style=\"font-size:20px\">Studio Microphone</span></strong></p><p><span style=\"color:#7A6558;font-size:12px\">USB-C · cardioid · desk stand</span></p><p><strong><span style=\"font-size:21px\">$109</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">COMPLETE THE DESK</span></strong></p><p><strong><span style=\"font-size:20px\">Studio Microphone</span></strong></p><p><span style=\"color:#7A6558;font-size:12px\">USB-C · cardioid · desk stand</span></p><p><strong><span style=\"font-size:21px\">$109</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/ecommerce2.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce2.json
@@ -92,8 +92,7 @@
               {
                 "id": "AdUv8E3G",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">CHECK-IN / 72 L</span></strong></p><p><strong><span style=\"font-size:34px\">The long-week suitcase.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Hard shell · quiet wheels · compression divider</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">CHECK-IN / 72 L</span></strong></p><p><strong><span style=\"font-size:34px\">The long-week suitcase.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Hard shell · quiet wheels · compression divider</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -132,8 +131,7 @@
               {
                 "id": "NsQhjZxf",
                 "type": "text",
-                "value": "<p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange</span><br /><strong><span style=\"font-size:29px\">$189</span></strong> <span style=\"color:#FF6B00;font-size:13px\">FREE SHIPPING</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange</span><br /><strong><span style=\"font-size:29px\">$189</span></strong> <span style=\"color:#FF6B00;font-size:13px\">FREE SHIPPING</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/ecommerce3.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce3.json
@@ -41,8 +41,7 @@
               {
                 "id": "iIdp_GCJ",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">NEW THIS WEEK</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Three arrivals, three different jobs.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">NEW THIS WEEK</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Three arrivals, three different jobs.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -192,8 +191,7 @@
                       {
                         "id": "VxBLBM01",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Transit Bomber</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">Lightweight shell</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$128</strong></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Transit Bomber</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">Lightweight shell</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$128</strong></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -398,8 +396,7 @@
                       {
                         "id": "BQj8ihmS",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Pocket Console</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">256 GB · OLED</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$249</strong></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Pocket Console</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">256 GB · OLED</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$249</strong></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -604,8 +601,7 @@
                       {
                         "id": "ildOMnJC",
                         "type": "text",
-                        "value": "<p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Daily Skincare</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">50 ml · fragrance free</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$42</strong></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"font-size:20px\"><strong>Daily Skincare</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:12px\">50 ml · fragrance free</span></p><p style=\"text-align:center\"><span style=\"font-size:21px\"><strong>$42</strong></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/ecommerce4.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce4.json
@@ -78,8 +78,7 @@
               {
                 "id": "ULzXEh65",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">LENA’S WEEKEND PICKS</span></strong></p><p><strong><span style=\"font-size:29px\">Two small upgrades I keep recommending.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Curated by Lena Park · product editor</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">LENA’S WEEKEND PICKS</span></strong></p><p><strong><span style=\"font-size:29px\">Two small upgrades I keep recommending.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Curated by Lena Park · product editor</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -174,8 +173,7 @@
               {
                 "id": "aRGaoXZO",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Weekend Pair</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Soft landing · everyday sole</span></p><p><strong><span style=\"font-size:22px\">$89</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Weekend Pair</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Soft landing · everyday sole</span></p><p><strong><span style=\"font-size:22px\">$89</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -293,8 +291,7 @@
               {
                 "id": "y57T2Wkb",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Citrus Six-Pack</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Dry finish · low sugar</span></p><p><strong><span style=\"font-size:22px\">$18</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Citrus Six-Pack</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Dry finish · low sugar</span></p><p><strong><span style=\"font-size:22px\">$18</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/ecommerce5.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce5.json
@@ -41,8 +41,7 @@
               {
                 "id": "DzK_Pze9",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">SIDE BY SIDE</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Choose the sound that fits the room.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">SIDE BY SIDE</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Choose the sound that fits the room.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -123,8 +122,7 @@
               {
                 "id": "RQDhG_ub",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:22px\">Focus Headphones</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Private listening<br />32-hour battery<br />Fold-flat design</span></p><p style=\"text-align:center\"><strong><span style=\"font-size:24px\">$159</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:22px\">Focus Headphones</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">Private listening<br />32-hour battery<br />Fold-flat design</span></p><p style=\"text-align:center\"><strong><span style=\"font-size:24px\">$159</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     12,
@@ -216,8 +214,7 @@
               {
                 "id": "DqeHT-Wb",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:22px\">Room Speaker</span></strong></p><p style=\"text-align:center\"><span style=\"color:#5A2B0A;font-size:13px\">Shared listening<br />18-hour battery<br />Room-filling sound</span></p><p style=\"text-align:center\"><strong><span style=\"font-size:24px\">$119</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:22px\">Room Speaker</span></strong></p><p style=\"text-align:center\"><span style=\"color:#5A2B0A;font-size:13px\">Shared listening<br />18-hour battery<br />Room-filling sound</span></p><p style=\"text-align:center\"><strong><span style=\"font-size:24px\">$119</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     12,

--- a/src/features/email-preview/catalog/blocks/ecommerce6.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce6.json
@@ -41,8 +41,7 @@
               {
                 "id": "m7EZZkv6",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKEND KIT</span></strong></p><p><strong><span style=\"font-size:31px\">Three pieces. One lighter departure.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKEND KIT</span></strong></p><p><strong><span style=\"font-size:31px\">Three pieces. One lighter departure.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -229,8 +228,7 @@
               {
                 "id": "KTq5wxOY",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">SAVE $42 AS A SET</span></strong></p><p><strong><span style=\"font-size:25px\">Carry-on + duffel + tote</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange · ships together</span></p><p><strong><span style=\"font-size:27px\">$248</span></strong> <span style=\"color:#7A6558;text-decoration:line-through\">$290</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">SAVE $42 AS A SET</span></strong></p><p><strong><span style=\"font-size:25px\">Carry-on + duffel + tote</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange · ships together</span></p><p><strong><span style=\"font-size:27px\">$248</span></strong> <span style=\"color:#7A6558;text-decoration:line-through\">$290</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/ecommerce7.json
+++ b/src/features/email-preview/catalog/blocks/ecommerce7.json
@@ -41,8 +41,7 @@
               {
                 "id": "bQp82CHO",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">SHOP BY USE</span></strong></p><p><strong><span style=\"font-size:31px\">Start with the part of the day.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">SHOP BY USE</span></strong></p><p><strong><span style=\"font-size:31px\">Start with the part of the day.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -137,8 +136,7 @@
               {
                 "id": "HPDhBJ4B",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Desk</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keyboards, cameras and focus tools · 12 items</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Desk</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keyboards, cameras and focus tools · 12 items</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -276,8 +274,7 @@
               {
                 "id": "dL7dKIhG",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Between plans</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Layers, bags and travel pieces · 18 items</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Between plans</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Layers, bags and travel pieces · 18 items</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -408,8 +405,7 @@
               {
                 "id": "w8CwvCPk",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Everyday</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Simple upgrades for repeat use · 9 items</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Everyday</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Simple upgrades for repeat use · 9 items</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature1.json
+++ b/src/features/email-preview/catalog/blocks/feature1.json
@@ -41,8 +41,7 @@
               {
                 "id": "fVWhVxNR",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THREE USEFUL OUTCOMES</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">A system that earns its place.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THREE USEFUL OUTCOMES</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">A system that earns its place.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "trwygxB6",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">FAST</span></strong></p><p><strong><span style=\"font-size:23px\">Start with structure.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Move from blank page to a useful first draft without rebuilding the basics.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">FAST</span></strong></p><p><strong><span style=\"font-size:23px\">Start with structure.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Move from blank page to a useful first draft without rebuilding the basics.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +140,7 @@
               {
                 "id": "3u9tdgZQ",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">CLEAR</span></strong></p><p><strong><span style=\"font-size:23px\">Edit with intent.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Keep hierarchy visible while content, media and actions continue to change.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">CLEAR</span></strong></p><p><strong><span style=\"font-size:23px\">Edit with intent.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Keep hierarchy visible while content, media and actions continue to change.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -183,8 +180,7 @@
               {
                 "id": "wNEQeATe",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">SAFE</span></strong></p><p><strong><span style=\"font-size:23px\">Send predictably.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Reuse email-safe patterns instead of discovering layout limits at export time.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">SAFE</span></strong></p><p><strong><span style=\"font-size:23px\">Send predictably.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Reuse email-safe patterns instead of discovering layout limits at export time.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature2.json
+++ b/src/features/email-preview/catalog/blocks/feature2.json
@@ -41,8 +41,7 @@
               {
                 "id": "PinD_6Z_",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">BUILT INTO THE WORKFLOW</span></strong></p><p><strong><span style=\"font-size:31px\">Follow the work, not the chrome.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">BUILT INTO THE WORKFLOW</span></strong></p><p><strong><span style=\"font-size:31px\">Follow the work, not the chrome.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "6amALi6n",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:24px\">01</span></strong></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:24px\">01</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -134,8 +132,7 @@
               {
                 "id": "uFmY7N8b",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:21px\">Choose a proven starting point.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Begin from a reusable block instead of a finished campaign theme.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:21px\">Choose a proven starting point.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Begin from a reusable block instead of a finished campaign theme.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -194,8 +191,7 @@
               {
                 "id": "nNgd2jrB",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#5A2B0A;font-size:24px\">02</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#5A2B0A;font-size:24px\">02</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -227,8 +223,7 @@
               {
                 "id": "rBYNjlS4",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:21px\">Refine the useful layer.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Change copy, media and hierarchy while the email-safe structure stays visible.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:21px\">Refine the useful layer.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Change copy, media and hierarchy while the email-safe structure stays visible.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -280,8 +275,7 @@
               {
                 "id": "rz99e6-n",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:24px\">03</span></strong></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:24px\">03</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -313,8 +307,7 @@
               {
                 "id": "0Xb5Uo9r",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:21px\">Export what you reviewed.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Carry the same structure from editor preview into JSON and final HTML.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:21px\">Export what you reviewed.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Carry the same structure from editor preview into JSON and final HTML.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature3.json
+++ b/src/features/email-preview/catalog/blocks/feature3.json
@@ -92,8 +92,7 @@
               {
                 "id": "NlZ9_EtI",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:12px\">01 / SYSTEM</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Structure before styling.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:13px\">Rows, cells and atoms stay explicit while the visual layer changes.</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:12px\">01 / SYSTEM</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:24px\">Structure before styling.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:13px\">Rows, cells and atoms stay explicit while the visual layer changes.</span></p></div>",
                 "spacing": {
                   "padding": [
                     20,
@@ -152,8 +151,7 @@
               {
                 "id": "zgfcMbAG",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:12px\">02 / CONTROL</span></strong></p><p><strong><span style=\"font-size:21px\">Tune the hierarchy.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Adjust spacing, alignment and emphasis without hiding the underlying tree.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:12px\">02 / CONTROL</span></strong></p><p><strong><span style=\"font-size:21px\">Tune the hierarchy.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Adjust spacing, alignment and emphasis without hiding the underlying tree.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -193,8 +191,7 @@
               {
                 "id": "N15GSkl_",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">03 / OUTPUT</span></strong></p><p><strong><span style=\"font-size:21px\">Keep the contract.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Preview, persistence and export work from the same versioned structure.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">03 / OUTPUT</span></strong></p><p><strong><span style=\"font-size:21px\">Keep the contract.</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Preview, persistence and export work from the same versioned structure.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature4.json
+++ b/src/features/email-preview/catalog/blocks/feature4.json
@@ -49,8 +49,7 @@
               {
                 "id": "af-jXkbc",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">GUIDED BY THE MESSAGE</span></strong></p><p><strong><span style=\"font-size:31px\">Three rules the editor keeps visible.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">GUIDED BY THE MESSAGE</span></strong></p><p><strong><span style=\"font-size:31px\">Three rules the editor keeps visible.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -89,8 +88,7 @@
               {
                 "id": "upvtlwC-",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:19px\">Hierarchy stays explicit</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">The selected block, row, cell and atom remain understandable.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:19px\">Hierarchy stays explicit</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">The selected block, row, cell and atom remain understandable.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -129,8 +127,7 @@
               {
                 "id": "GjvwIYa6",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:19px\">Changes stay local</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Edit the useful layer without rebuilding the surrounding email.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:19px\">Changes stay local</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Edit the useful layer without rebuilding the surrounding email.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -169,8 +166,7 @@
               {
                 "id": "O0qkaElV",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:19px\">Output stays predictable</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">The reviewed structure is the structure that gets exported.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:19px\">Output stays predictable</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">The reviewed structure is the structure that gets exported.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature5.json
+++ b/src/features/email-preview/catalog/blocks/feature5.json
@@ -41,8 +41,7 @@
               {
                 "id": "zm56tK7v",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">BEFORE / AFTER</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Replace guesswork with visible structure.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">BEFORE / AFTER</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Replace guesswork with visible structure.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "6OB5WFT7",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#7A6558;font-size:13px\">WITHOUT A SYSTEM</span></strong></p><p><strong><span style=\"font-size:24px\">Every send starts over.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">× Rebuild common sections<br />× Find hierarchy by trial<br />× Discover limits at export</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#7A6558;font-size:13px\">WITHOUT A SYSTEM</span></strong></p><p><strong><span style=\"font-size:24px\">Every send starts over.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">× Rebuild common sections<br />× Find hierarchy by trial<br />× Discover limits at export</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +140,7 @@
               {
                 "id": "3msE1Ei7",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">WITH A SYSTEM</span></strong></p><p><strong><span style=\"font-size:24px\">Each send starts ahead.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">✓ Reuse proven sections<br />✓ Edit a visible hierarchy<br />✓ Export the reviewed structure</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">WITH A SYSTEM</span></strong></p><p><strong><span style=\"font-size:24px\">Each send starts ahead.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">✓ Reuse proven sections<br />✓ Edit a visible hierarchy<br />✓ Export the reviewed structure</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature6.json
+++ b/src/features/email-preview/catalog/blocks/feature6.json
@@ -41,8 +41,7 @@
               {
                 "id": "XtwCHrMd",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">CAPABILITY MAP</span></strong></p><p><strong><span style=\"font-size:31px\">Four parts, one editing model.</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">CAPABILITY MAP</span></strong></p><p><strong><span style=\"font-size:31px\">Four parts, one editing model.</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -101,8 +100,7 @@
               {
                 "id": "MWIwIzdG",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">COMPOSE</span></strong></p><p><strong><span style=\"font-size:21px\">Reusable block library</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Start from a useful position rather than a completed campaign.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">COMPOSE</span></strong></p><p><strong><span style=\"font-size:21px\">Reusable block library</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Start from a useful position rather than a completed campaign.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -142,8 +140,7 @@
               {
                 "id": "HpBN9vJV",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:12px\">REFINE</span></strong></p><p><strong><span style=\"font-size:21px\">Explicit content tree</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Move from block to atom without losing the surrounding structure.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:12px\">REFINE</span></strong></p><p><strong><span style=\"font-size:21px\">Explicit content tree</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Move from block to atom without losing the surrounding structure.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -202,8 +199,7 @@
               {
                 "id": "AGjqRs6M",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:12px\">REVIEW</span></strong></p><p><strong><span style=\"font-size:21px\">Desktop and mobile preview</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Check hierarchy and stacking before the message leaves the editor.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:12px\">REVIEW</span></strong></p><p><strong><span style=\"font-size:21px\">Desktop and mobile preview</span></strong></p><p><span style=\"color:#5A2B0A;font-size:13px\">Check hierarchy and stacking before the message leaves the editor.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -243,8 +239,7 @@
               {
                 "id": "AThJ6Cr_",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:12px\">DELIVER</span></strong></p><p><strong><span style=\"font-size:21px\">JSON and HTML output</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Keep the versioned source and the email-ready result connected.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:12px\">DELIVER</span></strong></p><p><strong><span style=\"font-size:21px\">JSON and HTML output</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Keep the versioned source and the email-ready result connected.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature7.json
+++ b/src/features/email-preview/catalog/blocks/feature7.json
@@ -56,8 +56,7 @@
               {
                 "id": "PfVfez8T",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FFB16F;font-size:13px\">FEATURE SPOTLIGHT</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:34px\">The tree stays visible while the message changes.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:14px\">A focused capability with enough context to explain why it matters.</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p><strong><span style=\"color:#FFB16F;font-size:13px\">FEATURE SPOTLIGHT</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:34px\">The tree stays visible while the message changes.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:14px\">A focused capability with enough context to explain why it matters.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -180,8 +179,7 @@
               {
                 "id": "pPDzrwdI",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:18px\">Select precisely</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Block, row, cell or atom.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:18px\">Select precisely</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Block, row, cell or atom.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -213,8 +211,7 @@
               {
                 "id": "_5AcZGDd",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:18px\">Edit locally</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Change only the intended layer.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:18px\">Edit locally</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Change only the intended layer.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -246,8 +243,7 @@
               {
                 "id": "Dg1KJr_S",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:18px\">Review clearly</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keep the whole email in context.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:18px\">Review clearly</span></strong><br /><span style=\"color:#7A6558;font-size:13px\">Keep the whole email in context.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/feature8.json
+++ b/src/features/email-preview/catalog/blocks/feature8.json
@@ -42,8 +42,7 @@
               {
                 "id": "-B9mThms",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">BL</span></strong></p><p style=\"text-align:center\"><strong>Block library</strong><br /><span style=\"color:#7A6558;font-size:12px\">Useful starts</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">BL</span></strong></p><p style=\"text-align:center\"><strong>Block library</strong><br /><span style=\"color:#7A6558;font-size:12px\">Useful starts</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -75,8 +74,7 @@
               {
                 "id": "4ZA182Yo",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">TR</span></strong></p><p style=\"text-align:center\"><strong>Visible tree</strong><br /><span style=\"color:#7A6558;font-size:12px\">Explicit layers</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">TR</span></strong></p><p style=\"text-align:center\"><strong>Visible tree</strong><br /><span style=\"color:#7A6558;font-size:12px\">Explicit layers</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -108,8 +106,7 @@
               {
                 "id": "DHl9GyMB",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">PV</span></strong></p><p style=\"text-align:center\"><strong>Live preview</strong><br /><span style=\"color:#7A6558;font-size:12px\">Desktop + mobile</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">PV</span></strong></p><p style=\"text-align:center\"><strong>Live preview</strong><br /><span style=\"color:#7A6558;font-size:12px\">Desktop + mobile</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -141,8 +138,7 @@
               {
                 "id": "gQY-3ufY",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">EX</span></strong></p><p style=\"text-align:center\"><strong>Safe export</strong><br /><span style=\"color:#7A6558;font-size:12px\">JSON + HTML</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:27px\">EX</span></strong></p><p style=\"text-align:center\"><strong>Safe export</strong><br /><span style=\"color:#7A6558;font-size:12px\">JSON + HTML</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer1-dark.json
+++ b/src/features/email-preview/catalog/blocks/footer1-dark.json
@@ -40,8 +40,7 @@
               {
                 "id": "F1DAddrA",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street<br />San Francisco, CA 94105</span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street<br />San Francisco, CA 94105</span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer1-light.json
+++ b/src/features/email-preview/catalog/blocks/footer1-light.json
@@ -40,8 +40,7 @@
               {
                 "id": "F1LAddrA",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street<br />San Francisco, CA 94105</span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street<br />San Francisco, CA 94105</span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer2-dark.json
+++ b/src/features/email-preview/catalog/blocks/footer2-dark.json
@@ -159,8 +159,7 @@
               {
                 "id": "VZ179NCb",
                 "type": "text",
-                "value": "<p><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer2-light.json
+++ b/src/features/email-preview/catalog/blocks/footer2-light.json
@@ -159,8 +159,7 @@
               {
                 "id": "fhipuLNA",
                 "type": "text",
-                "value": "<p><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer3-dark.json
+++ b/src/features/email-preview/catalog/blocks/footer3-dark.json
@@ -168,8 +168,7 @@
               {
                 "id": "4Wgc0GIV",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer3-light.json
+++ b/src/features/email-preview/catalog/blocks/footer3-light.json
@@ -168,8 +168,7 @@
               {
                 "id": "ZYePtmR0",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer4-dark.json
+++ b/src/features/email-preview/catalog/blocks/footer4-dark.json
@@ -116,8 +116,7 @@
               {
                 "id": "OmC7c7EO",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/footer4-light.json
+++ b/src/features/email-preview/catalog/blocks/footer4-light.json
@@ -116,8 +116,7 @@
               {
                 "id": "tzjWvWr0",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p>",
-                "color": "#AAAAAA",
+                "value": "<div style=\"color:#AAAAAA\"><p style=\"text-align:center\"><span style=\"font-size:14px;color:rgb(170, 170, 170)\">500 Howard Street San Francisco, CA 94105<br /><u><a href=\"https://example.com\" style=\"color:rgb(170, 170, 170)\">hello@example.com</a></u></span></p></div>",
                 "spacing": {
                   "margin": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header1.json
+++ b/src/features/email-preview/catalog/blocks/header1.json
@@ -41,8 +41,7 @@
               {
                 "id": "ddaBopcy",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">INDEPENDENT NOTES ON USEFUL THINGS</span></strong></p><p><strong><span style=\"font-size:56px\">FIELD / NOTES</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">INDEPENDENT NOTES ON USEFUL THINGS</span></strong></p><p><strong><span style=\"font-size:56px\">FIELD / NOTES</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -106,8 +105,7 @@
               {
                 "id": "qJfNrUJ3",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:22px\">Issue 08</span></strong><br /><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER · 6 MIN READ</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:22px\">Issue 08</span></strong><br /><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER · 6 MIN READ</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -139,8 +137,7 @@
               {
                 "id": "Dr82ex7P",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:28px\">A clearer way to choose what stays.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:15px\">Stories about products, habits and the small decisions that shape everyday work.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:28px\">A clearer way to choose what stays.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:15px\">Stories about products, habits and the small decisions that shape everyday work.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header10.json
+++ b/src/features/email-preview/catalog/blocks/header10.json
@@ -49,8 +49,7 @@
               {
                 "id": "rl3vEwAz",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">THE EVERYDAY EDIT</span></strong></p><p><strong><span style=\"font-size:39px\">Three objects worth making room for.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A collection-led opening with one promise and a visible range, not three competing cards.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">THE EVERYDAY EDIT</span></strong></p><p><strong><span style=\"font-size:39px\">Three objects worth making room for.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A collection-led opening with one promise and a visible range, not three competing cards.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header2.json
+++ b/src/features/email-preview/catalog/blocks/header2.json
@@ -42,8 +42,7 @@
               {
                 "id": "3Hij89zy",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">ROOM-FILLING SOUND</span></strong></p><p><strong><span style=\"font-size:37px\">Small speaker. Serious presence.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A classic media-right hero for a focused product launch.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">ROOM-FILLING SOUND</span></strong></p><p><strong><span style=\"font-size:37px\">Small speaker. Serious presence.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A classic media-right hero for a focused product launch.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header3.json
+++ b/src/features/email-preview/catalog/blocks/header3.json
@@ -92,8 +92,7 @@
               {
                 "id": "GcUqSejt",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">THE LIGHT LAYER</span></strong></p><p><strong><span style=\"font-size:36px\">Built for the weather between plans.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A media-left opening with room for a concise product promise.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">THE LIGHT LAYER</span></strong></p><p><strong><span style=\"font-size:36px\">Built for the weather between plans.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A media-left opening with room for a concise product promise.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header4.json
+++ b/src/features/email-preview/catalog/blocks/header4.json
@@ -41,8 +41,7 @@
               {
                 "id": "3KBRQAq_",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKEND PAIR</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:40px\">Move light. Land softly.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:15px\">A centered product-first hero with one clear destination.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">THE WEEKEND PAIR</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:40px\">Move light. Land softly.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:15px\">A centered product-first hero with one clear destination.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header5.json
+++ b/src/features/email-preview/catalog/blocks/header5.json
@@ -51,8 +51,7 @@
               {
                 "id": "BbeNVD6u",
                 "type": "text",
-                "value": "<p style=\"text-align:right\"><strong><span style=\"color:#FFB16F;font-size:12px\">01 / OPENING FRAME</span></strong></p><p><strong><span style=\"color:#FFB16F;font-size:13px\">A NEW WAY THROUGH</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:40px\">Make the first impression feel inevitable.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A focused opening with one clear promise and a direct next step.</span></p>",
-                "color": "#FFFFFF",
+                "value": "<div style=\"color:#FFFFFF\"><p style=\"text-align:right\"><strong><span style=\"color:#FFB16F;font-size:12px\">01 / OPENING FRAME</span></strong></p><p><strong><span style=\"color:#FFB16F;font-size:13px\">A NEW WAY THROUGH</span></strong></p><p><strong><span style=\"color:#FFFFFF;font-size:40px\">Make the first impression feel inevitable.</span></strong></p><p><span style=\"color:#FFD9B8;font-size:15px\">A focused opening with one clear promise and a direct next step.</span></p></div>",
                 "spacing": {
                   "padding": [
                     30,

--- a/src/features/email-preview/catalog/blocks/header6.json
+++ b/src/features/email-preview/catalog/blocks/header6.json
@@ -55,8 +55,7 @@
               {
                 "id": "CzYxqrlH",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">LIVE DEMO / THURSDAY</span></strong></p><p><strong><span style=\"font-size:36px\">Hear the difference before we name it.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:15px\">The presenter demonstrates the product and points attention toward the launch message.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">LIVE DEMO / THURSDAY</span></strong></p><p><strong><span style=\"font-size:36px\">Hear the difference before we name it.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:15px\">The presenter demonstrates the product and points attention toward the launch message.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header7.json
+++ b/src/features/email-preview/catalog/blocks/header7.json
@@ -41,8 +41,7 @@
               {
                 "id": "yjTzXq8X",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD NOTES / ISSUE 08</span></strong></p><p><strong><span style=\"font-size:37px\">What we choose to carry.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">An editorial issue header with a visible author and a wide visual chapter marker.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">FIELD NOTES / ISSUE 08</span></strong></p><p><strong><span style=\"font-size:37px\">What we choose to carry.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">An editorial issue header with a visible author and a wide visual chapter marker.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -183,8 +182,7 @@
               {
                 "id": "x5D2zIH7",
                 "type": "text",
-                "value": "<p><strong>Maya Chen</strong><br /><span style=\"color:#7A6558;font-size:13px\">Editor · objects, travel and everyday systems</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong>Maya Chen</strong><br /><span style=\"color:#7A6558;font-size:13px\">Editor · objects, travel and everyday systems</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header8.json
+++ b/src/features/email-preview/catalog/blocks/header8.json
@@ -49,8 +49,7 @@
               {
                 "id": "5o7auu5x",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:42px\">24</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:42px\">24</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     18,
@@ -82,8 +81,7 @@
               {
                 "id": "DLK75x6A",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#5A2B0A;font-size:13px\">ONLINE WORKSHOP · 10:00</span></strong></p><p><strong><span style=\"font-size:33px\">Design the first screen together.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Date, topic and registration action stay visible at a glance.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#5A2B0A;font-size:13px\">ONLINE WORKSHOP · 10:00</span></strong></p><p><strong><span style=\"font-size:33px\">Design the first screen together.</span></strong></p><p><span style=\"color:#5A2B0A;font-size:14px\">Date, topic and registration action stay visible at a glance.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/header9.json
+++ b/src/features/email-preview/catalog/blocks/header9.json
@@ -42,8 +42,7 @@
               {
                 "id": "k131YWQ-",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">PLAY ANYWHERE</span></strong></p><p><strong><span style=\"font-size:37px\">A whole library in both hands.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A device introduction with direct platform actions and no decorative app chrome.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">PLAY ANYWHERE</span></strong></p><p><strong><span style=\"font-size:37px\">A whole library in both hands.</span></strong></p><p><span style=\"color:#7A6558;font-size:15px\">A device introduction with direct platform actions and no decorative app chrome.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional1.json
+++ b/src/features/email-preview/catalog/blocks/transactional1.json
@@ -42,8 +42,7 @@
               {
                 "id": "LvYO-BY-",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">ORDER #CARD-2048</span></strong></p><p><strong><span style=\"font-size:32px\">Thanks, Maya. Your order is confirmed.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">We’ve received your payment and will send tracking as soon as the package leaves our studio.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">ORDER #CARD-2048</span></strong></p><p><strong><span style=\"font-size:32px\">Thanks, Maya. Your order is confirmed.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">We’ve received your payment and will send tracking as soon as the package leaves our studio.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -83,8 +82,7 @@
               {
                 "id": "lhq1W0Ia",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:13px\">CONFIRMED</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:26px\">$159.00</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:13px\">CONFIRMED</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:26px\">$159.00</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -179,8 +177,7 @@
               {
                 "id": "IP8FFa3_",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:19px\">Focus Headphones</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange · Qty 1</span></p><p><strong><span style=\"font-size:18px\">$159.00</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:19px\">Focus Headphones</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Sand / Orange · Qty 1</span></p><p><strong><span style=\"font-size:18px\">$159.00</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional2.json
+++ b/src/features/email-preview/catalog/blocks/transactional2.json
@@ -42,8 +42,7 @@
               {
                 "id": "Cs9YGMsV",
                 "type": "text",
-                "value": "<p><span style=\"font-size:13px\"><strong>RECEIPT / 04 AUG 2026</strong></span></p><p><span style=\"font-size:31px\"><strong>Payment received.</strong></span></p><p><span style=\"font-size:14px\">Receipt #RC-7391 · Visa ending in 2048</span></p>",
-                "color": "#000000",
+                "value": "<div style=\"color:#000000\"><p><span style=\"font-size:13px\"><strong>RECEIPT / 04 AUG 2026</strong></span></p><p><span style=\"font-size:31px\"><strong>Payment received.</strong></span></p><p><span style=\"font-size:14px\">Receipt #RC-7391 · Visa ending in 2048</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -75,8 +74,7 @@
               {
                 "id": "T5e456GX",
                 "type": "text",
-                "value": "<p style=\"text-align:right\"><span style=\"font-size:12px\">TOTAL PAID</span><span><br /></span><span style=\"font-size:31px\"><strong>$248.00</strong></span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"font-size:12px\">TOTAL PAID</span><span><br /></span><span style=\"font-size:31px\"><strong>$248.00</strong></span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -155,8 +153,7 @@
                       {
                         "id": "wOHYaMMb",
                         "type": "text",
-                        "value": "<p><span style=\"font-size:13px\">Weekend kit</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"font-size:13px\">Weekend kit</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -188,8 +185,7 @@
                       {
                         "id": "Jucyvz7J",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span style=\"font-size:13px\">$228.00</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"font-size:13px\">$228.00</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -240,8 +236,7 @@
                       {
                         "id": "9O8uFIJk",
                         "type": "text",
-                        "value": "<p><span style=\"font-size:13px\">Shipping</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"font-size:13px\">Shipping</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -273,8 +268,7 @@
                       {
                         "id": "hHHcv-iZ",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span style=\"font-size:13px\">$12.00</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"font-size:13px\">$12.00</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -325,8 +319,7 @@
                       {
                         "id": "0FrdbBqH",
                         "type": "text",
-                        "value": "<p><span style=\"font-size:13px\">Tax</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"font-size:13px\">Tax</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -358,8 +351,7 @@
                       {
                         "id": "tPdHw2ow",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span style=\"font-size:13px\">$8.00</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"font-size:13px\">$8.00</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -454,8 +446,7 @@
                       {
                         "id": "dLc-148S",
                         "type": "text",
-                        "value": "<p><span style=\"font-size:13px\">Total</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"font-size:13px\">Total</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -487,8 +478,7 @@
                       {
                         "id": "WiJOCsLz",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span style=\"font-size:13px\"><strong>$248.00</strong></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"font-size:13px\"><strong>$248.00</strong></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/transactional3.json
+++ b/src/features/email-preview/catalog/blocks/transactional3.json
@@ -42,8 +42,7 @@
               {
                 "id": "68pFlYxU",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">TRACKING #OR-592-184</span></strong></p><p><strong><span style=\"font-size:31px\">Your package is on the move.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Estimated delivery: Thursday, 6 August</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">TRACKING #OR-592-184</span></strong></p><p><strong><span style=\"font-size:31px\">Your package is on the move.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Estimated delivery: Thursday, 6 August</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -146,8 +145,7 @@
               {
                 "id": "U4PSDoft",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:14px\">01</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#1F1712;font-size:15px\">Confirmed</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">4 Aug · 09:12</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:14px\">01</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#1F1712;font-size:15px\">Confirmed</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">4 Aug · 09:12</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -188,8 +186,7 @@
               {
                 "id": "-KhaQaFA",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:rgb(255, 107, 0);font-size:14px\"><strong>02</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(31, 23, 18);font-size:15px\"><strong>In transit</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:11px\">5 Aug · 14:40</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:rgb(255, 107, 0);font-size:14px\"><strong>02</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(31, 23, 18);font-size:15px\"><strong>In transit</strong></span></p><p style=\"text-align:center\"><span style=\"color:rgb(122, 101, 88);font-size:11px\">5 Aug · 14:40</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -230,8 +227,7 @@
               {
                 "id": "knn3c3UQ",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:14px\">03</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#1F1712;font-size:15px\">Delivered</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">Expected 6 Aug</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:14px\">03</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#1F1712;font-size:15px\">Delivered</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">Expected 6 Aug</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional4.json
+++ b/src/features/email-preview/catalog/blocks/transactional4.json
@@ -112,8 +112,7 @@
                       {
                         "id": "XioyX_R-",
                         "type": "text",
-                        "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">DELIVERED TODAY</span></strong></p><p><strong><span style=\"font-size:32px\">Your order has arrived.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Left at the front desk at 14:32.</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">DELIVERED TODAY</span></strong></p><p><strong><span style=\"font-size:32px\">Your order has arrived.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Left at the front desk at 14:32.</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -171,8 +170,7 @@
                       {
                         "id": "wbX8l5Dv",
                         "type": "text",
-                        "value": "<p><span style=\"color:#7A6558;font-size:12px\">DELIVERY ADDRESS</span><br><strong>18 Market Street<br>Brooklyn, NY 11201</strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"color:#7A6558;font-size:12px\">DELIVERY ADDRESS</span><br><strong>18 Market Street<br>Brooklyn, NY 11201</strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/transactional5.json
+++ b/src/features/email-preview/catalog/blocks/transactional5.json
@@ -44,8 +44,7 @@
               {
                 "id": "iAIbf0lw",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:42px\">24</span></strong><br><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:42px\">24</span></strong><br><span style=\"color:#5A2B0A;font-size:13px\">SEPTEMBER</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -77,8 +76,7 @@
               {
                 "id": "wrXDHKIF",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">BOOKING CONFIRMED</span></strong></p><p><strong><span style=\"font-size:29px\">Product systems workshop</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Thursday · 10:00–11:30 AM<br>Online · Room opens 15 minutes early</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">BOOKING CONFIRMED</span></strong></p><p><strong><span style=\"font-size:29px\">Product systems workshop</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Thursday · 10:00–11:30 AM<br>Online · Room opens 15 minutes early</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -118,8 +116,7 @@
               {
                 "id": "U6_VGmuF",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">BOOKING ID</span><br><strong><span style=\"font-size:18px\">WS-4821</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:11px\">BOOKING ID</span><br><strong><span style=\"font-size:18px\">WS-4821</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional6.json
+++ b/src/features/email-preview/catalog/blocks/transactional6.json
@@ -41,8 +41,7 @@
               {
                 "id": "FaXd6YW5",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FFB16F;font-size:13px\">SECURITY REQUEST</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:32px\">Reset your password.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#FFD9B8;font-size:14px\">We received a request to update the password for maya@example.com. This link expires in 30 minutes.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FFB16F;font-size:13px\">SECURITY REQUEST</span></strong></p><p style=\"text-align:center\"><strong><span style=\"color:#FFFFFF;font-size:32px\">Reset your password.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#FFD9B8;font-size:14px\">We received a request to update the password for maya@example.com. This link expires in 30 minutes.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -153,8 +152,7 @@
               {
                 "id": "g7sUPOE8",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:#A88976;font-size:12px\">If you didn’t request this, you can safely ignore this message. Your password will stay unchanged.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#A88976;font-size:12px\">If you didn’t request this, you can safely ignore this message. Your password will stay unchanged.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional7.json
+++ b/src/features/email-preview/catalog/blocks/transactional7.json
@@ -41,8 +41,7 @@
               {
                 "id": "fr1cojSg",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">VERIFY YOUR EMAIL</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Enter this one-time code.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:14px\">Use it to finish signing in. The code expires in 10 minutes.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">VERIFY YOUR EMAIL</span></strong></p><p style=\"text-align:center\"><strong><span style=\"font-size:31px\">Enter this one-time code.</span></strong></p><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:14px\">Use it to finish signing in. The code expires in 10 minutes.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -95,8 +94,7 @@
               {
                 "id": "3UEPYWWR",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">4</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">4</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -130,8 +128,7 @@
               {
                 "id": "DpZ143Qw",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">8</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">8</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -165,8 +162,7 @@
               {
                 "id": "pLbZnrRT",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">2</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">2</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -200,8 +196,7 @@
               {
                 "id": "YuTvJ15W",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">9</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">9</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -235,8 +230,7 @@
               {
                 "id": "ovhagGe9",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">1</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">1</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -270,8 +264,7 @@
               {
                 "id": "BSUJjwmI",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"font-size:25px\">6</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"font-size:25px\">6</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -321,8 +314,7 @@
               {
                 "id": "VAH7jbNz",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:12px\">Never share this code with anyone, including support.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:12px\">Never share this code with anyone, including support.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/catalog/blocks/transactional8.json
+++ b/src/features/email-preview/catalog/blocks/transactional8.json
@@ -44,8 +44,7 @@
               {
                 "id": "pSqq6Gis",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:rgb(255, 255, 255);font-size:56px\"><strong>!</strong></span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:rgb(255, 255, 255);font-size:56px\"><strong>!</strong></span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -76,8 +75,7 @@
               {
                 "id": "F1qoqtVq",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">PAYMENT NEEDS ATTENTION</span></strong></p><p><strong><span style=\"font-size:30px\">We couldn’t renew your plan.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Your workspace remains active until 12 August.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">PAYMENT NEEDS ATTENTION</span></strong></p><p><strong><span style=\"font-size:30px\">We couldn’t renew your plan.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Your workspace remains active until 12 August.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -164,8 +162,7 @@
                       {
                         "id": "a5p6Dedq",
                         "type": "text",
-                        "value": "<p><span style=\"color:#7A6558;font-size:13px\">Card</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"color:#7A6558;font-size:13px\">Card</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -197,8 +194,7 @@
                       {
                         "id": "uryO6D3K",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span><span style=\"color:#1F1712;font-size:13px\">Visa ···· 2048</span></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span><span style=\"color:#1F1712;font-size:13px\">Visa ···· 2048</span></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -249,8 +245,7 @@
                       {
                         "id": "WfjwF-UR",
                         "type": "text",
-                        "value": "<p><span style=\"color:#7A6558;font-size:13px\">Amount due</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"color:#7A6558;font-size:13px\">Amount due</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -282,8 +277,7 @@
                       {
                         "id": "_KcdbAHM",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><strong><span style=\"color:#1F1712;font-size:13px\">$24.00</span></strong></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><strong><span style=\"color:#1F1712;font-size:13px\">$24.00</span></strong></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -334,8 +328,7 @@
                       {
                         "id": "4Br8l3Dn",
                         "type": "text",
-                        "value": "<p><span style=\"color:#7A6558;font-size:13px\">Next attempt</span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p><span style=\"color:#7A6558;font-size:13px\">Next attempt</span></p></div>",
                         "spacing": {
                           "padding": [
                             0,
@@ -367,8 +360,7 @@
                       {
                         "id": "HebCqYZb",
                         "type": "text",
-                        "value": "<p style=\"text-align:right\"><span><span style=\"color:#1F1712;font-size:13px\">8 August</span></span></p>",
-                        "color": "#1F1712",
+                        "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span><span style=\"color:#1F1712;font-size:13px\">8 August</span></span></p></div>",
                         "spacing": {
                           "padding": [
                             0,

--- a/src/features/email-preview/catalog/blocks/transactional9.json
+++ b/src/features/email-preview/catalog/blocks/transactional9.json
@@ -41,8 +41,7 @@
               {
                 "id": "bJvyc6F-",
                 "type": "text",
-                "value": "<p><strong><span style=\"color:#FF6B00;font-size:13px\">REFUND ISSUED</span></strong></p><p><strong><span style=\"font-size:31px\">$89.00 is on its way back.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Most banks post refunds within 3–5 business days.</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"color:#FF6B00;font-size:13px\">REFUND ISSUED</span></strong></p><p><strong><span style=\"font-size:31px\">$89.00 is on its way back.</span></strong></p><p><span style=\"color:#7A6558;font-size:14px\">Most banks post refunds within 3–5 business days.</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -137,8 +136,7 @@
               {
                 "id": "oTXgwVfG",
                 "type": "text",
-                "value": "<p><strong><span style=\"font-size:18px\">Weekend Pair</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Return #RT-1184<br>Refund to Visa ···· 2048</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p><strong><span style=\"font-size:18px\">Weekend Pair</span></strong></p><p><span style=\"color:#7A6558;font-size:13px\">Return #RT-1184<br>Refund to Visa ···· 2048</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -170,8 +168,7 @@
               {
                 "id": "pT0gK2A_",
                 "type": "text",
-                "value": "<p style=\"text-align:right\"><span style=\"color:#7A6558;font-size:12px\">REFUND TOTAL</span><br><strong><span style=\"font-size:23px\">$89.00</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:right\"><span style=\"color:#7A6558;font-size:12px\">REFUND TOTAL</span><br><strong><span style=\"font-size:23px\">$89.00</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -230,8 +227,7 @@
               {
                 "id": "3wiPltcU",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">01 · APPROVED</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">01 · APPROVED</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -271,8 +267,7 @@
               {
                 "id": "KJ0xkUbH",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">02 · SENT</span></strong></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><strong><span style=\"color:#FF6B00;font-size:13px\">02 · SENT</span></strong></p></div>",
                 "spacing": {
                   "padding": [
                     0,
@@ -312,8 +307,7 @@
               {
                 "id": "3SWicpYf",
                 "type": "text",
-                "value": "<p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">03 · BANK POSTING</span></p>",
-                "color": "#1F1712",
+                "value": "<div style=\"color:#1F1712\"><p style=\"text-align:center\"><span style=\"color:#7A6558;font-size:13px\">03 · BANK POSTING</span></p></div>",
                 "spacing": {
                   "padding": [
                     0,

--- a/src/features/email-preview/ui/BlockRendererRowNode.vue
+++ b/src/features/email-preview/ui/BlockRendererRowNode.vue
@@ -43,10 +43,7 @@ function atomSpacingStyle(atom: Atom, options: { includePadding?: boolean } = {}
 }
 
 function textAtomStyle(atom: Extract<Atom, { type: 'text' }>): CSSProperties {
-  return {
-    ...atomSpacingStyle(atom),
-    ...(atom.color ? { color: atom.color } : {}),
-  }
+  return atomSpacingStyle(atom)
 }
 
 function buttonStyle(atom: Extract<Atom, { type: 'button' }>): CSSProperties {

--- a/src/features/email-preview/ui/ExportBlockRendererRowNode.vue
+++ b/src/features/email-preview/ui/ExportBlockRendererRowNode.vue
@@ -35,10 +35,7 @@ function atomSpacingStyle(atom: Atom, options: { includePadding?: boolean } = {}
 }
 
 function textAtomStyle(atom: Extract<Atom, { type: 'text' }>): CSSProperties {
-  return {
-    ...atomSpacingStyle(atom),
-    ...(atom.color ? { color: atom.color } : {}),
-  }
+  return atomSpacingStyle(atom)
 }
 
 function buttonStyle(atom: Extract<Atom, { type: 'button' }>): CSSProperties {

--- a/tests/entities/block/block-factory.test.ts
+++ b/tests/entities/block/block-factory.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { createTextAtom } from '@/entities/block'
+
+describe('block factory', () => {
+  it('stores the default text color inside default and custom HTML values', () => {
+    const defaultAtom = createTextAtom()
+    const customAtom = createTextAtom(
+      '<p>Base <span style="color:#FF6B00">accent</span></p><ul><li>Item</li></ul>',
+    )
+
+    expect(defaultAtom.value).toBe('<div style="color:#111827"><p>Text</p></div>')
+    expect(customAtom.value).toBe(
+      '<div style="color:#111827"><p>Base <span style="color:#FF6B00">accent</span></p><ul><li>Item</li></ul></div>',
+    )
+    expect(defaultAtom).not.toHaveProperty('color')
+    expect(customAtom).not.toHaveProperty('color')
+  })
+})

--- a/tests/entities/template/inline-text-typography.test.ts
+++ b/tests/entities/template/inline-text-typography.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createBlockNode } from '@/entities/block'
 import {
   createRuntimeComponents,
+  parseTemplateExportPayload,
   sanitizeTextEditorHtml,
   TEMPLATE_EXPORT_VERSION,
 } from '@/entities/template'
@@ -18,6 +19,67 @@ import {
 import { useCanvas, useHistory, useTemplateIO } from '@/features/editor/model'
 
 describe('inline text typography contract', () => {
+  it('keeps inherited and nested colors across sanitizer and Tiptap round-trips', () => {
+    const input = sanitizeTextEditorHtml(
+      '<div style="color:#1F1712"><p>Base <span style="color:#FF6B00">accent</span></p><ul><li>List item</li></ul><p>Second root</p></div>',
+    )
+    const editor = new Editor({ content: input, extensions: createInlineTextExtensions() })
+
+    const output = sanitizeTextEditorHtml(editor.getHTML())
+    editor.destroy()
+
+    expect(output).toContain('<div style="color:rgb(31, 23, 18)">')
+    expect(output).toContain('<span style="color:rgb(255, 107, 0)">accent</span>')
+    expect(output).toContain('<ul><li><p>List item</p></li></ul>')
+
+    const secondEditor = new Editor({ content: output, extensions: createInlineTextExtensions() })
+    expect(sanitizeTextEditorHtml(secondEditor.getHTML())).toBe(output)
+    secondEditor.destroy()
+  })
+
+  it('drops legacy top-level text color from the canonical payload', () => {
+    const component = {
+      id: 'component',
+      version: 2 as const,
+      block: createBlockNode('Text'),
+    }
+    const atom = component.block.rows[0].cells[0].atoms[0]
+    Object.assign(atom, { color: '#1F1712', unknown: 'drop-me' })
+
+    const result = parseTemplateExportPayload({
+      version: TEMPLATE_EXPORT_VERSION,
+      meta: {
+        id: 'template',
+        title: 'Text',
+        createdAt: '1970-01-01T00:00:00.000Z',
+        updatedAt: '1970-01-01T00:00:00.000Z',
+      },
+      editor: {
+        general: {
+          padding: [0, 0, 0, 0],
+          background: {
+            color: '#ffffff',
+            image: '',
+            repeat: 'no-repeat',
+            size: 'cover',
+            position: 'center',
+          },
+          font: 'Arial',
+          previewText: '',
+        },
+      },
+      canvas: { components: [component] },
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.payload?.canvas.components[0].block.rows[0].cells[0].atoms[0]).not.toHaveProperty(
+      'color',
+    )
+    expect(result.payload?.canvas.components[0].block.rows[0].cells[0].atoms[0]).not.toHaveProperty(
+      'unknown',
+    )
+  })
+
   it('keeps legacy HTML and accepted typography while removing unsafe content', () => {
     const input = [
       '<p onclick="alert(1)" style="text-align: center">Legacy <strong>bold</strong></p>',


### PR DESCRIPTION
## Summary
- remove the legacy top-level TextAtom.color field from the domain, sanitizer, canvas tools, preview, and export
- migrate 181 text atoms across 70 catalog presets to inherited HTML color while preserving nested overrides
- keep template export, localStorage, and component versions at v2
- add factory and Tiptap round-trip regression coverage

## Validation
- pnpm -s vue-tsc --noEmit
- pnpm -s test (15 tests)
- scoped ESLint
- pnpm -s build
- catalog validation in card-catalog-tools: 78 presets
- desktop and mobile visual smoke checks